### PR TITLE
Replaced spurious tab indentation with spaces

### DIFF
--- a/ina260/controller.py
+++ b/ina260/controller.py
@@ -86,7 +86,7 @@ class Controller:
         if current & (1 << 15):
             current -= 65535
 
-	current *= 0.00125 # 1.25mA/bit
+        current *= 0.00125 # 1.25mA/bit
 
         return current
 


### PR DESCRIPTION
Trying to import the module results in:

```
Traceback (most recent call last):
  File "/home/frillip/code/field-control-panel/sensors.py", line 8, in <module>
    from ina260.controller import Controller
  File "/usr/local/lib/python3.8/dist-packages/ina260/controller.py", line 89
    current *= 0.00125 # 1.25mA/bit
                                  ^
TabError: inconsistent use of tabs and spaces in indentation
```

Replaced tab with spaces and it now imports correctly.